### PR TITLE
GetComponentInChildren() 최적화 및 OnDeath() 메서드의 Blink 값 지정 문제 해결

### DIFF
--- a/MoreCharacterSelector/BodyReplacements.cs
+++ b/MoreCharacterSelector/BodyReplacements.cs
@@ -5,80 +5,78 @@ using UnityEngine;
 
 namespace MoreCharacterSelector
 {
-	public class MRAKULA : BodyReplacementBase
-	{
-		public bool Blink = true;
+    public class MRAKULA : BodyReplacementBase
+    {
+        public bool Blink = true;
 
-		//Required universally
-		protected override GameObject LoadAssetsAndReturnModel()
-		{
-			string model_name = "Akula";
-			return Assets.MainAssetBundle.LoadAsset<GameObject>(model_name);
-		}
+        //Required universally
+        protected override GameObject LoadAssetsAndReturnModel()
+        {
+            string model_name = "Akula";
+            return Assets.MainAssetBundle.LoadAsset<GameObject>(model_name);
+        }
 
-		//Miku mod specific scripts. Delete this if you have no custom scripts to add. 
-		protected override void AddModelScripts()
-		{
-			UseNoPostProcessing = true;
-			StartCoroutine(OnIdle());
+        //Miku mod specific scripts. Delete this if you have no custom scripts to add. 
+        protected override void AddModelScripts()
+        {
+            UseNoPostProcessing = true;
+            StartCoroutine(OnIdle());
+        }
 
-		}
+        protected override void OnEmoteStart(int emoteId)
+        {
+            var meshRenderer = replacementModel.GetComponentInChildren<SkinnedMeshRenderer>();
+            meshRenderer.SetBlendShapeWeight(7, 0);
+            meshRenderer.SetBlendShapeWeight(62, 0);
+            meshRenderer.SetBlendShapeWeight(76, 0);
 
-		protected override void OnEmoteStart(int emoteId)
-		{
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(7, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(62, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(76, 0);
+            meshRenderer.SetBlendShapeWeight(5, 0);
+            meshRenderer.SetBlendShapeWeight(42, 0);
+            meshRenderer.SetBlendShapeWeight(91, 0);
 
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(5, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(42, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(91, 0);
+            if (emoteId == 1)
+            {
+                meshRenderer.SetBlendShapeWeight(5, 100);
+                meshRenderer.SetBlendShapeWeight(42, 100);
+                meshRenderer.SetBlendShapeWeight(91, (float)87.5);
+            }
+            if (emoteId == 2)
+            {
+                meshRenderer.SetBlendShapeWeight(7, 100);
+                meshRenderer.SetBlendShapeWeight(62, 26);
+                meshRenderer.SetBlendShapeWeight(76, 100);
+            }
+            Blink = false;
+        }
 
-			if (emoteId == 1)
-			{
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(5, 100);
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(42, 100);
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(91, (float)87.5);
-			}
-			if (emoteId == 2)
-			{
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(7, 100);
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(62, 26);
-				replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(76, 100);
-			}
-			Blink = false;
-		}
+        protected override void OnEmoteEnd()
+        {
+            var meshRenderer = replacementModel.GetComponentInChildren<SkinnedMeshRenderer>();
+            meshRenderer.SetBlendShapeWeight(7, 0);
+            meshRenderer.SetBlendShapeWeight(62, 0);
+            meshRenderer.SetBlendShapeWeight(76, 0);
 
-		protected override void OnEmoteEnd()
-		{
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(7, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(62, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(76, 0);
+            meshRenderer.SetBlendShapeWeight(5, 0);
+            meshRenderer.SetBlendShapeWeight(42, 0);
+            meshRenderer.SetBlendShapeWeight(91, 0);
+            Blink = true;
+        }
 
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(5, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(42, 0);
-			replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(91, 0);
-			Blink = true;
-		}
+        protected override void OnDeath()
+        {
+            Blink = true;
 
-		protected override void OnDeath()
-		{
-			foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
-			{
-
-				var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
-				if (blinkIndex != -1)
-				{
-					r.SetBlendShapeWeight(blinkIndex, 100f);
-					Blink = false;
-				}
-				else
-				{
-					Blink = true;
-				}
-			}
-		}
-		/*protected override void OnDeath()
+            foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
+                if (blinkIndex != -1)
+                {
+                    r.SetBlendShapeWeight(blinkIndex, 100f);
+                    Blink = false;
+                }
+            }
+        }
+        /*protected override void OnDeath()
         {
             foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
             {
@@ -93,150 +91,156 @@ namespace MoreCharacterSelector
             }
         }*/
 
-		IEnumerator OnIdle()
-		{
-			while (true)
-			{
-				if (Blink == true)
-				{
-					foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-					{
-						var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
-						if (blinkIndex != -1)
-						{
-							r.SetBlendShapeWeight(blinkIndex, 100f);
-						}
-					}
+        IEnumerator OnIdle()
+        {
+            while (true)
+            {
+                if (Blink == true)
+                {
+                    foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+                    {
+                        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
+                        if (blinkIndex != -1)
+                        {
+                            r.SetBlendShapeWeight(blinkIndex, 100f);
+                        }
+                    }
 
-					yield return new WaitForSeconds(0.2f);
+                    yield return new WaitForSeconds(0.2f);
 
-					foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-					{
-						var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
-						if (blinkIndex != -1)
-						{
-							r.SetBlendShapeWeight(blinkIndex, 0f);
-						}
-					}
+                    foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+                    {
+                        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
+                        if (blinkIndex != -1)
+                        {
+                            r.SetBlendShapeWeight(blinkIndex, 0f);
+                        }
+                    }
 
-					yield return new WaitForSeconds(15f);
-				}
-				else
-				{
-					yield return null;
-				}
-			}
-		}
-	}
+                    yield return new WaitForSeconds(15f);
+                }
+                else
+                {
+                    yield return null;
+                }
+            }
+        }
+    }
 
-	public class MRPEPE : BodyReplacementBase
-	{
-		public bool Blink = true;
-		protected override GameObject LoadAssetsAndReturnModel()
-		{
-			string model_name = "pepe";
-			return Assets.MainAssetBundle.LoadAsset<GameObject>(model_name);
-		}
+    public class MRPEPE : BodyReplacementBase
+    {
+        public bool Blink = true;
 
-		protected override void AddModelScripts()
-		{
-			UseNoPostProcessing = true;
-			StartCoroutine(OnIdle());
-		}
+        protected override GameObject LoadAssetsAndReturnModel()
+        {
+            string model_name = "pepe";
+            return Assets.MainAssetBundle.LoadAsset<GameObject>(model_name);
+        }
 
-		protected override void OnEmoteStart(int emoteId)
-		{
-			foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-			{
-				var lockIndex = r.sharedMesh.GetBlendShapeIndex("Lock");
-				var sadIndex = r.sharedMesh.GetBlendShapeIndex("Sad");
-				if (lockIndex != -1)
-				{
-					r.SetBlendShapeWeight(lockIndex, 0f);
-					if (emoteId == 1)
-					{
-						r.SetBlendShapeWeight(lockIndex, 100f);
-					}
-				}
-				if (sadIndex != -1)
-				{
-					r.SetBlendShapeWeight(sadIndex, 0f);
-					if (emoteId == 2)
-					{
-						r.SetBlendShapeWeight(sadIndex, 100f);
-					}
-				}
-			}
-			Blink = false;
-		}
-		protected override void OnEmoteEnd()
-		{
-			foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-			{
-				var lockIndex = r.sharedMesh.GetBlendShapeIndex("Lock");
-				var sadIndex = r.sharedMesh.GetBlendShapeIndex("Sad");
-				if (lockIndex != -1)
-				{
-					r.SetBlendShapeWeight(lockIndex, 0f);
-				}
-				if(sadIndex != -1)
-				{
-					r.SetBlendShapeWeight(sadIndex, 0f);
-				}
-			}
-			Blink = true;
-		}
+        protected override void AddModelScripts()
+        {
+            UseNoPostProcessing = true;
+            StartCoroutine(OnIdle());
+        }
 
-		protected override void OnDeath()
-		{
-			foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
-			{
-				var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
-				if (blinkIndex != -1)
-				{
-					r.SetBlendShapeWeight(blinkIndex, 100f);
-					Blink = false;
-				}
-				else
-				{
-					Blink = true;
-				}
-			}
-		}
+        protected override void OnEmoteStart(int emoteId)
+        {
+            foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                var lockIndex = r.sharedMesh.GetBlendShapeIndex("Lock");
+                var sadIndex = r.sharedMesh.GetBlendShapeIndex("Sad");
+                if (lockIndex != -1)
+                {
+                    if (emoteId == 1)
+                    {
+                        r.SetBlendShapeWeight(lockIndex, 100f);
+                    }
+                    else
+                    {
+                        r.SetBlendShapeWeight(lockIndex, 0f);
+                    }
+                }
+                if (sadIndex != -1)
+                {
+                    if (emoteId == 2)
+                    {
+                        r.SetBlendShapeWeight(sadIndex, 100f);
+                    }
+                    else
+                    {
+                        r.SetBlendShapeWeight(sadIndex, 0f);
+                    }
+                }
+            }
+            Blink = false;
+        }
 
-		IEnumerator OnIdle()
-		{
-			while (true)
-			{
-				if (Blink == true)
-				{
-					foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-					{
-						var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
-						if (blinkIndex != -1)
-						{
-							r.SetBlendShapeWeight(blinkIndex, 100f);
-						}
-					}
+        protected override void OnEmoteEnd()
+        {
+            foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                var lockIndex = r.sharedMesh.GetBlendShapeIndex("Lock");
+                var sadIndex = r.sharedMesh.GetBlendShapeIndex("Sad");
+                if (lockIndex != -1)
+                {
+                    r.SetBlendShapeWeight(lockIndex, 0f);
+                }
+                if (sadIndex != -1)
+                {
+                    r.SetBlendShapeWeight(sadIndex, 0f);
+                }
+            }
+            Blink = true;
+        }
 
-					yield return new WaitForSeconds(0.3f);
+        protected override void OnDeath()
+        {
+            Blink = true;
 
-					foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
-					{
-						var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
-						if (blinkIndex != -1)
-						{
-							r.SetBlendShapeWeight(blinkIndex, 0f);
-						}
-					}
+            foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
+                if (blinkIndex != -1)
+                {
+                    r.SetBlendShapeWeight(blinkIndex, 100f);
+                    Blink = false;
+                }
+            }
+        }
 
-					yield return new WaitForSeconds(15f);
-				}
-				else
-				{
-					yield return null;
-				}
-			}
-		}
-	}
+        IEnumerator OnIdle()
+        {
+            while (true)
+            {
+                if (Blink == true)
+                {
+                    foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+                    {
+                        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
+                        if (blinkIndex != -1)
+                        {
+                            r.SetBlendShapeWeight(blinkIndex, 100f);
+                        }
+                    }
+
+                    yield return new WaitForSeconds(0.3f);
+
+                    foreach (var r in replacementModel.GetComponentsInChildren<SkinnedMeshRenderer>())
+                    {
+                        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
+                        if (blinkIndex != -1)
+                        {
+                            r.SetBlendShapeWeight(blinkIndex, 0f);
+                        }
+                    }
+
+                    yield return new WaitForSeconds(15f);
+                }
+                else
+                {
+                    yield return null;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## GetComponentInChildren() 최적화
class MRAKULA -> OnEmoteStart(int emoteId) 부분을 보면
```csharp
protected override void OnEmoteStart(int emoteId)
{
    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(7, 0);
    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(62, 0);
    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(76, 0);

    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(5, 0);
    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(42, 0);
    replacementModel.GetComponentInChildren<SkinnedMeshRenderer>().SetBlendShapeWeight(91, 0);
    ...
}
```
으로 작성되어있었습니다.

여기서 `GetComponentInChildren<SkinnedMeshRenderer>();`를 여러번 호출하는 것을 볼 수 있는데,
이는 속도가 느릴 뿐더러 GC Allocation이 매 호출마다 발생한다고 알고 있습니다.
따라서 이로 인해 플레이 중 끊김 현상이 발생할 수 있다고 생각합니다.

[https://rito15.github.io/posts/unity-opt-script-optimization/#getcomponent-%EB%8C%80%EC%8B%A0-trygetcomponent-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0](url)

AddModelScripts() 메서드에서 먼저 호출하고 클래스 변수로 가져와서 사용하는 방식 또한 고려해봤으나, 정상적으로 동작하지 않았습니다.
(컴포넌트를 잘못 가져와서? 아니면 초기화가 완전히 되지 않을 채로 GetComponent를 시도해서 일 수도 있다고 생각합니다...)

아래와 같이 수정했습니다 (+ OnEmoteEnd() 메서드에서도 동일하게 적용했습니다)
```csharp
protected override void OnEmoteStart(int emoteId)
{
    var meshRenderer = replacementModel.GetComponentInChildren<SkinnedMeshRenderer>();
    meshRenderer.SetBlendShapeWeight(7, 0);
    meshRenderer.SetBlendShapeWeight(62, 0);
    meshRenderer.SetBlendShapeWeight(76, 0);

    meshRenderer.SetBlendShapeWeight(5, 0);
    meshRenderer.SetBlendShapeWeight(42, 0);
    meshRenderer.SetBlendShapeWeight(91, 0);
    ...
}
```


**정확하지 않을 수** 있지만 System.Diagnostics.Stopwatch를 사용해서 ElapsedTicks로 성능테스트를 해봤습니다.
-- AKULA 모델로 테스트한 결과입니다 --

#### 수정 전
![test_before](https://github.com/Hu-Myo/More-Character-Selector/assets/25785584/a43a9f1f-402b-4386-af69-c726ef403962)

#### 수정 후
![test_after](https://github.com/Hu-Myo/More-Character-Selector/assets/25785584/ee79034b-3e93-4e1f-8ad0-27f410c6d44d)

심하면 약 5배 정도의 속도 차이가 날 수 있음을 알 수 있었습니다.

매 프레임마다 호출되는건 아니기 때문에 일반적인 플레이 중 큰 성능차이는 없을 수 있지만,
성능이 좋지않은 컴퓨터에서
누군가 해당 모델을 착용하고 감정표현을 사용했을 때 갑작스런 프레임 드랍이 생길 수도 있다고 생각합니다.

## OnDeath() 메서드의 Blink 값 지정 문제

class MRAKULA -> OnDeath() 부분을 보면
```csharp
protected override void OnDeath()
{
    foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
    {
        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("EyeClose");
	if (blinkIndex != -1)
	{
	    r.SetBlendShapeWeight(blinkIndex, 100f);
	    Blink = false;
	}
	else
	{
	    Blink = true;
	}
    }
}
```

1. foreach 내부에서 코드가 동작합니다.
2. sharedMesh를 참조하여 GetBlendShapeIndex("EyeClose")로 인덱스를 가져오려고 시도합니다.
3. if (blinkIndex != -1) 에서 인덱스를 찾았을 경우에는 -1이 아니므로
4. 그 아래 코드에서 Blink 값을 false 로 지정하여 눈을 깜빡이지 않도록 합니다.
5. 그러나 위 if문에서 인덱스를 못찾았다고 판단했을 경우 
6. 눈을 깜빡일 수 있도록(Blink 값을 true로 지정) 하고 있습니다.

(prefab 내부가 어떻게 짜여져 있는지 확인은 하지 않았기 때문에 잘은 모릅니다.. 
그렇기 때문에 제 추론이 틀렸을수도 있습니다!)

적어도 blinkIndex가 -1이 아니였다면(EyeClose 블렌드쉐이프를 찾았다면) Blink값을 false로 고정하여
죽은 플레이어의 시체는 눈을 감긴 상태로 유지시켜야하지 않을까 싶습니다.

만약 SkinnedMeshRenderer 컴포넌트들을 찾아서 반복문을 돌릴때 한번은 EyeClose를 찾았지만, 그 다음 반복에서 EyeClose를 찾지 못하는 상황이 발생하게 된다면 

첫번째 반복에서 Blink를 false로 바꿨지만
두번째 반복에서 Blink를 true로 다시 바뀔수도 있기 때문입니다.

수정된 코드   +페페 모델쪽 코드에도 동일하게 적용하였습니다
(설명을 위해 주석을 추가하였습니다, 실제 파일에서는 주석이 없습니다!)
```csharp
protected override void OnDeath()
{
    // CloseEye 블렌드쉐이프를 찾지 못할 경우를 대비하여 true로 초기화
    Blink = true;

    foreach (var r in replacementDeadBody.GetComponentsInChildren<SkinnedMeshRenderer>())
    {
        var blinkIndex = r.sharedMesh.GetBlendShapeIndex("CloseEye");
        if (blinkIndex != -1)
        {
            r.SetBlendShapeWeight(blinkIndex, 100f);
            // CloseEye 블렌드쉐이프를 찾았다면 눈이 감긴상태로 유지하도록...
            Blink = false;
        }
    }
}
```
